### PR TITLE
remove set_image() from Show2D + cache, mkdir

### DIFF
--- a/widget/src/quantem/widget/array_utils.py
+++ b/widget/src/quantem/widget/array_utils.py
@@ -1,11 +1,15 @@
 """Array utilities for widgets. NumPy + PyTorch input."""
 import numpy as np
-import torch
 
 
 def to_numpy(data, dtype: np.dtype | None = None) -> np.ndarray:
     """Convert NumPy / PyTorch / Dataset to NumPy."""
-    if isinstance(data, torch.Tensor):
+    try:
+        import torch
+        is_tensor = isinstance(data, torch.Tensor)
+    except ImportError:
+        is_tensor = False
+    if is_tensor:
         result = data.detach().cpu().numpy()
     elif isinstance(data, np.ndarray):
         result = data

--- a/widget/src/quantem/widget/show2d.py
+++ b/widget/src/quantem/widget/show2d.py
@@ -575,66 +575,6 @@ class Show2D(anywidget.AnyWidget):
         except (ValueError, KeyError):
             pass
 
-    def set_image(self, data, labels=None):
-        """Replace the displayed image(s). Preserves all display settings."""
-        if hasattr(data, "array") and hasattr(data, "name") and hasattr(data, "sampling"):
-            data = data.array
-        if isinstance(data, list):
-            images = [to_numpy(d) for d in data]
-            shapes = [img.shape for img in images]
-            if len(set(shapes)) > 1:
-                max_h = max(s[0] for s in shapes)
-                max_w = max(s[1] for s in shapes)
-                images = [_resize_image(img, max_h, max_w) for img in images]
-            data = np.stack(images)
-        else:
-            data = to_numpy(data)
-        if data.ndim == 2:
-            data = data[np.newaxis, ...]
-        if data.dtype == np.float32:
-            self._data = np.array(data, dtype=np.float32, copy=True)
-        else:
-            self._data = np.asarray(data, dtype=np.float32)
-        self._data_original = [self._data[i] for i in range(self._data.shape[0])]
-        self._originals_are_views = True
-        self.n_images = int(data.shape[0])
-
-        # Auto-bin for display (reuse existing _display_bin or recompute)
-        gpu_budget_mb = 2500
-        per_image_mb = (data.shape[1] * data.shape[2] * 4 * 3) / (1024 * 1024)
-        total_mb = self.n_images * per_image_mb
-        self._display_bin = 1
-        if total_mb > gpu_budget_mb:
-            for bf in [2, 4, 8]:
-                if total_mb / (bf * bf) <= gpu_budget_mb:
-                    self._display_bin = bf
-                    break
-            else:
-                self._display_bin = 8
-
-        if self._display_bin > 1:
-            from quantem.widget.array_utils import bin2d
-            self._display_data = bin2d(self._data, factor=self._display_bin, mode="mean")
-            self.height = int(self._display_data.shape[1])
-            self.width = int(self._display_data.shape[2])
-            self._display_bin_factor = self._display_bin
-            if getattr(self, "_verbose", True):
-                print(f"  Display bin {self._display_bin}×: {data.shape[1]}×{data.shape[2]} → {self.height}×{self.width}")
-        else:
-            self._display_data = self._data
-            self.height = int(data.shape[1])
-            self.width = int(data.shape[2])
-            self._display_bin_factor = 1
-
-        self.image_rotations = [0] * self.n_images
-        if labels is not None:
-            self.labels = list(labels)
-        else:
-            self.labels = [f"Image {i+1}" for i in range(self.n_images)]
-        self.selected_idx = 0
-        self._compute_all_stats()
-        self._update_all_frames()
-
     def __repr__(self) -> str:
         if self.n_images > 1:
             shape = f"{self.n_images}×{self.height}×{self.width}"

--- a/widget/src/quantem/widget/show4dstem.py
+++ b/widget/src/quantem/widget/show4dstem.py
@@ -527,6 +527,8 @@ class Show4DSTEM(anywidget.AnyWidget):
         ])
         # Observe compound roi_center for batched updates from JS
         self.observe(self._on_roi_center_change, names=["roi_center"])
+        # Invalidate precomputed virtual image caches when calibration changes
+        self.observe(self._on_calibration_change, names=["center_row", "center_col", "bf_radius"])
 
         # Initialize default ROI at BF center — batch to avoid redundant observer callbacks
         with self.hold_trait_notifications():
@@ -2161,6 +2163,12 @@ class Show4DSTEM(anywidget.AnyWidget):
         """Create rectangular mask (boolean tensor on device)."""
         mask = (torch.abs(self._det_col_coords - cx) <= half_width) & (torch.abs(self._det_row_coords - cy) <= half_height)
         return mask
+
+    def _on_calibration_change(self, change=None):
+        self._cached_bf_virtual = None
+        self._cached_abf_virtual = None
+        self._cached_adf_virtual = None
+        self._cached_haadf_virtual = None
 
     def _precompute_common_virtual_images(self):
         """Pre-compute BF/ABF/ADF/HAADF virtual image bytes. Annular ranges match

--- a/widget/src/quantem/widget/state.py
+++ b/widget/src/quantem/widget/state.py
@@ -42,4 +42,6 @@ def unwrap_state_payload(payload: dict[str, Any], *, require_envelope: bool = Fa
 
 
 def save_state_file(path: str | pathlib.Path, widget_name: str, state: dict[str, Any]) -> None:
-    pathlib.Path(path).write_text(json.dumps(wrap_state_dict(widget_name, state), indent=2))
+    p = pathlib.Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(wrap_state_dict(widget_name, state), indent=2))


### PR DESCRIPTION
- Removal of set_image() from Show2D: Same as #7 but for Show2D as well, albeit being not as large of an issue
- Invalidate virtual image cache on calibration change
- mkdir in save_state_file
- LAzy import torch in array_utils to avoid unnecessary imports for Show2D